### PR TITLE
Added Relay Environment Selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
   "dependencies": {
     "bulma": "^0.9.0",
     "bulma-components": "0.0.5",
+    "deep-object-diff": "^1.1.0",
     "json-beautify": "^1.1.1",
     "node-sass": "^4.14.1",
     "react-input-range": "^1.3.0",

--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -43,9 +43,8 @@ export default class Agent extends EventEmitter<{|
   };
 
   refreshStore = (id: EnvironmentID) => {
-    console.log('hi from refreshStore in agent')
     const wrapper = this._environmentWrappers[id];
-    wrapper.sendStoreRecords();
+    wrapper && wrapper.sendStoreRecords();
   };
 
   onEnvironmentInitialized = (data: mixed) => {
@@ -60,12 +59,10 @@ export default class Agent extends EventEmitter<{|
   };
 
   onStoreData = (data: mixed) => {
-    console.log('onstoredata line 62 agent js')
     this._bridge.send('storeRecords', [data]);
   };
 
   onEnvironmentEvent = (data: mixed) => {
-    console.log('hello from onEnvEvent in agent')
     this._bridge.send('events', [data]);
   };
 }

--- a/src/devtools/DevTools.js
+++ b/src/devtools/DevTools.js
@@ -34,26 +34,26 @@ export type ViewElementSource = (id: number) => void;
 
 export type Props = {|
   bridge: FrontendBridge,
-  // defaultTab?: TabID,
-  // showTabBar?: boolean,
-  store: Store,
-  viewElementSourceFunction?: ?ViewElementSource,
-  viewElementSourceRequiresFileLocation?: boolean,
+    // defaultTab?: TabID,
+    // showTabBar?: boolean,
+    store: Store,
+      viewElementSourceFunction ?: ? ViewElementSource,
+      viewElementSourceRequiresFileLocation ?: boolean,
 
-  // This property is used only by the web extension target.
-  // The built-in tab UI is hidden in that case, in favor of the browser's own panel tabs.
-  // This is done to save space within the app.
-  // Because of this, the extension needs to be able to change which tab is active/rendered.
-  // overrideTab?: TabID,
+      // This property is used only by the web extension target.
+      // The built-in tab UI is hidden in that case, in favor of the browser's own panel tabs.
+      // This is done to save space within the app.
+      // Because of this, the extension needs to be able to change which tab is active/rendered.
+      // overrideTab?: TabID,
 
-  // TODO: Cleanup multi-tabs in webextensions
-  // To avoid potential multi-root trickiness, the web extension uses portals to render tabs.
-  // The root <DevTools> app is rendered in the top-level extension window,
-  // but individual tabs (e.g. Components, Profiling) can be rendered into portals within their browser panels.
-  rootContainer?: Element,
-  // networkPortalContainer?: Element,
-  settingsPortalContainer?: Element,
-  storeInspectorPortalContainer?: Element,
+      // TODO: Cleanup multi-tabs in webextensions
+      // To avoid potential multi-root trickiness, the web extension uses portals to render tabs.
+      // The root <DevTools> app is rendered in the top-level extension window,
+      // but individual tabs (e.g. Components, Profiling) can be rendered into portals within their browser panels.
+      rootContainer ?: Element,
+      // networkPortalContainer?: Element,
+      settingsPortalContainer ?: Element,
+      storeInspectorPortalContainer ?: Element,
 |};
 
 const networkTab = {
@@ -95,8 +95,7 @@ export default function DevTools({
   const [currentEnvID, setCurrentEnvID] = useState(environmentIDs[0]);
 
   const [selector, setSelector] = useState("Store");
-  const allRecords = JSON.stringify(store.getAllRecords());
-  
+
   const setEnv = useCallback(() => {
     const ids = store.getEnvironmentIDs();
 
@@ -108,56 +107,68 @@ export default function DevTools({
   }, [store, currentEnvID]);
 
   useEffect(() => {
+    setEnv();
     store.addListener('environmentInitialized', setEnv);
     return () => {
       store.removeListener('environmentInitialized', setEnv);
     };
   }, [store, setEnv]);
 
-  function handleTabClick (e, tab) {
+  function handleTabClick(e, tab) {
     console.log(tab);
     setSelector(tab);
   }
 
-  const environmentChange = useCallback(e => {
+  const handleChange = useCallback(e => {
+    console.log(parseInt(e.target.value));
     setCurrentEnvID(parseInt(e.target.value));
   }, []);
 
   return (
     <BridgeContext.Provider value={bridge}>
       <StoreContext.Provider value={store}>
-        <div className="tabs is-toggle">
-          <ul>
-            <li className={selector === "Store" && "is-active"}>
-              <a onClick={(e) => handleTabClick(e, "Store")}>
-                <span className="icon is-small">
-                  <i className="fas fa-database"></i>
-                </span>
-                <span>Store</span>
-              </a>
-            </li>
-            <li className={selector === "Network" && "is-active"}>
-              <a
-                onClick={(e) => {
-                  handleTabClick(e, "Network");
-                }}
-              >
-                <span className="icon is-small">
-                  <i className="fas fa-network-wired"></i>
-                </span>
-                <span>Network</span>
-              </a>
-            </li>
-          </ul>
+        <div className="navigation">
+          <form className="env-select">
+            <select className="env-select" onChange={handleChange}>
+              {environmentIDs.map(id => {
+                return (
+                  <option key={id} value={id}>{store.getEnvironmentName(id) || id}</option>
+                );
+              })}
+            </select>
+          </form>
+          <div className="tabs is-toggle">
+            <ul>
+              <li className={selector === "Store" && "is-active"}>
+                <a onClick={(e) => handleTabClick(e, "Store")}>
+                  <span className="icon is-small">
+                    <i className="fas fa-database"></i>
+                  </span>
+                  <span>Store</span>
+                </a>
+              </li>
+              <li className={selector === "Network" && "is-active"}>
+                <a
+                  onClick={(e) => {
+                    handleTabClick(e, "Network");
+                  }}
+                >
+                  <span className="icon is-small">
+                    <i className="fas fa-network-wired"></i>
+                  </span>
+                  <span>Network</span>
+                </a>
+              </li>
+            </ul>
+          </div>
         </div>
         <div className={selector === "Store" ? "columns" : "is-hidden"}>
-          <StoreTimeline currentEnvID={currentEnvID} portalContainer={storeInspectorPortalContainer}/>
-        {/* <StoreDisplayer currentEnvID={currentEnvID}  store={store.getAllRecords()[0]} test /> */}
+          <StoreTimeline currentEnvID={currentEnvID} portalContainer={storeInspectorPortalContainer} />
         </div>
         <div className={selector === "Network" ? "columns" : "is-hidden"}>
           <NetworkDisplayer />
         </div>
       </StoreContext.Provider>
-    </BridgeContext.Provider>
+    </BridgeContext.Provider >
   );
 }

--- a/src/devtools/view/StoreTimeline.js
+++ b/src/devtools/view/StoreTimeline.js
@@ -13,23 +13,23 @@ const StoreTimeline = ({ currentEnvID }) => {
   const [liveStore, setLiveStore] = useState(store.getRecords(currentEnvID));
   const [timeline, setTimeline] = useState({
     [currentEnvID]: [{
-      label: "current",
+      label: "at startup",
       date: Date.now(),
       storage: liveStore,
     }]
   });
 
   const handleClick = (e) => {
-    console.log('BAAAAAAAA!!!!')
     e.preventDefault();
     const timelineInsert = {};
     const timeStamp = Date.now();
     timelineInsert.label = timelineLabel;
     timelineInsert.date = timeStamp;
     timelineInsert.storage = liveStore;
-    const newTimeline = [timelineInsert].concat(timeline[currentEnvID])
+    const newTimeline = timeline[currentEnvID].concat([timelineInsert])
     setTimeline({ ...timeline, [currentEnvID]: newTimeline });
-    e.target.value = "";
+    setTimelineLabel('');
+    setSnapshotIndex(newTimeline.length)
   }
 
   const updateStoreHelper = (storeObj) => {
@@ -53,19 +53,22 @@ const StoreTimeline = ({ currentEnvID }) => {
 
   useEffect(() => {
     console.log("AAAAAAAAAAAAAAAAAAAHHHHHHHHHHHHHHHHH")
-    setLiveStore(store.getRecords(currentEnvID));
+    const allRecords = store.getRecords(currentEnvID);
+    setLiveStore(allRecords);
 
     if (!timeline[currentEnvID]) {
       const newTimeline = {
         ...timeline, [currentEnvID]: [{
           label: "current",
           date: Date.now(),
-          storage: liveStore,
+          storage: allRecords,
         }]
       }
       setTimeline(newTimeline);
+      setSnapshotIndex(1)
+    } else {
+      setSnapshotIndex(timeline[currentEnvID].length)
     }
-
   }, [currentEnvID]);
 
   console.log('currenttimeilne', timeline)
@@ -82,18 +85,18 @@ const StoreTimeline = ({ currentEnvID }) => {
         <div className="snapshots">
           <h2 className="slider-textcolor">Store Timeline</h2>
           <InputRange
-            maxValue={timeline[currentEnvID] ? timeline[currentEnvID].length - 1 : 0}
+            maxValue={timeline[currentEnvID] ? timeline[currentEnvID].length : 0}
             minValue={0}
             value={snapshotIndex}
             onChange={value => setSnapshotIndex(value)} />
           <div className="snapshot-nav">
             <button class="button is-small" onClick={() => { if (snapshotIndex !== 0) setSnapshotIndex(snapshotIndex - 1) }}>Backward</button>
-            <button class="button is-small" onClick={() => setSnapshotIndex(0)}>Current</button>
-            <button class="button is-small" onClick={() => { if (snapshotIndex !== timeline[currentEnvID].length - 1) setSnapshotIndex(snapshotIndex + 1) }}>Forward</button>
+            <button class="button is-small" onClick={() => setSnapshotIndex(timeline[currentEnvID].length)}>Current</button>
+            <button class="button is-small" onClick={() => { if (snapshotIndex !== timeline[currentEnvID].length) setSnapshotIndex(snapshotIndex + 1) }}>Forward</button>
           </div>
         </div>
       </div>
-      <StoreDisplayer store={snapshotIndex === 0 ? liveStore : timeline[currentEnvID][snapshotIndex].storage} />
+      <StoreDisplayer store={(!timeline[currentEnvID] || !timeline[currentEnvID][snapshotIndex] || snapshotIndex === timeline[currentEnvID].length) ? liveStore : timeline[currentEnvID][snapshotIndex].storage} />
     </React.Fragment>
   )
 }


### PR DESCRIPTION
Added a dropdown selector for different relay environments:
- Refactored timeline to be an object containing arrays where the key is the environment

Changed snapshot selector logic:
- Snapshot now adds a "on startup" snapshot on startup
- Live store is now highest selector index
- Added logic so timeline cursor now defaults to live store (i.e. largest index)
- Corrected bug where store mutations replace current snapshot displayed on screen
- Added conditional functionality to fix any conflicts with persisting store and snapshot data
- Snapshots persist even when jumping between relay environments

Fixed bug on startup where wrapper is not defined throwing a "cannot read sendStoreRecords property of undefined" error