### PR TITLE
Added relay example apps as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "relay-examples"]
+	path = relay-examples
+	url = https://github.com/relayjs/relay-examples.git

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "start:prod": "cd ./shells/dev && cross-env NODE_ENV=production cross-env TARGET=local webpack-dev-server --open",
     "test-debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "test": "jest --config ./__test__/jest.config.json",
+    "install-app": "npm i --prefix ./relay-examples/todo/",
+    "start-test-app": "npm start --prefix ./relay-examples/todo/",
     "relay": "relay-compiler",
     "watch:chrome:frontend": "cross-env NODE_ENV=development node ./shells/browser/chrome/watch",
     "docker-test": "docker-compose up"


### PR DESCRIPTION
Added relay example apps as submodule
- Added install script to install example apps, install of example app triggered by running `npm run install-app`
- Added start script to run the submodule, can now run example app with `npm run start-test-app`