### PR TITLE
styling for StoreTimeline updated for side/bottom panel view

### DIFF
--- a/shells/browser/shared/view/styles.scss
+++ b/shells/browser/shared/view/styles.scss
@@ -233,7 +233,7 @@ button.button.is-small.is-link {
   }
   .snapshot-nav {
     margin-top: 0;
-    width: 40%;
+    width: 100%;
   }
   .input-range {
     width: 70%;

--- a/src/devtools/view/StoreTimeline.js
+++ b/src/devtools/view/StoreTimeline.js
@@ -112,7 +112,7 @@ const StoreTimeline = ({ currentEnvID }) => {
             </button>
           </div>
         </div>
-        <div className="snapshots columns is-multiline">
+        <div className="snapshots">
           <div className="timeline-nav column is-full-desktop is-flex-mobile" id="timeline-mini-col">
             <InputRange
               maxValue={


### PR DESCRIPTION
Changed:
- width of the snapshot-nav class
- removed the columns and multi-line class from the snapshot div